### PR TITLE
feat: upgrade unpacker.py to fix UPX header if needed

### DIFF
--- a/unpacker.py
+++ b/unpacker.py
@@ -30,20 +30,70 @@ class Unpacker(ServiceBase):
             request.result.add_section(ResultSection(f"{os.path.basename(uresult.displayname)} successfully unpacked!",
                                                      body=caveat_msg))
 
-    def _unpack_upx(self, packedfile, outputpath, displayname):
-        # Test the file to see if UPX agrees with our identification.
+    def _check_upx(self, packedfile):
+        # Test the file to see if UPX agrees with our identification
         stdout, stderr = Popen((self.upx_exe, '-t', packedfile),
                                stdout=PIPE, stderr=PIPE).communicate()
+        return (stdout, stderr)
 
-        if b'[OK]' in stdout and b'Tested 1 file' in stdout:
+    def _fix_p_info(self, packedfile)
+        stream = open(packedfile, 'r+b')
+        buff = stream.read()
+        upx_index = buff.find(b'UPX!')
+        if upx_index == -1:
+            self.log.info('Could not find UPX l_info struct')
+            return None
+        l_info_offset = upx_index - 4
+        if l_info_offset < 0:
+            self.log.info('Invalid l_info_offset')
+            return None
+        p_filesize = buff[l_info_offset + 16 : l_info_offset + 20]
+        p_blocksize = buff[l_info_offset + 20 : l_info_offset + 24]
+        stream.seek(-12, os.SEEK_END)
+        filesize = stream.read(4)
+        # check p_filesize and p_blocksize of packed file, if corrupt (set to 0), fix it by set the real filesize value
+        if p_blocksize  == b'\x00\x00\x00\x00' or p_filesize == b'\x00\x00\x00\x00':
+            self.log.info('UPX altered p_blocksize / p_filesize - try to restore')
+            stream.seek(l_info_offset + 16)
+            stream.write(filesize)
+            stream.seek(l_info_offset + 20)
+            stream.write(filesize)
+            stream.close()
+
+    def _unpack_upx(self, packedfile, outputpath, displayname):
+        i = 0
+        # run check in while to recheck after fix
+        # call fix function if UPX return p_info corrupted
+        # used a counter to avoid infinite loop
+        while i < 2:
+            check_stdout, check_stderr = self._check_upx(packedfile)
+            if b'[OK]' in check_stdout and b'Tested 1 file' in check_stdout:
+                check = True
+                break
+            elif b'p_info corrupted' in check_stderr:
+                check = False
+                self.log.info('UPX File p_info corrupted')
+                self._fix_p_info(packedfile)
+                i = i+1
+            else:
+                check = False
+                break
+
+        # Check is True when UPX -t validates file - we could try to unpack
+        if check is True:
             stdout, stderr = Popen((self.upx_exe, '-d', '-o', outputpath, packedfile),
                                    stdout=PIPE, stderr=PIPE).communicate()
 
             if b'Unpacked 1 file' in stdout:
                 # successfully unpacked.
                 return UnpackResult(True, outputpath, displayname, {'stdout': stdout[:1024]})
+            else:
+                # add a return if unpacking didn't work
+                self.log.info(f'UPX extractor failed to unpack file:\n{stderr[:1024]}\n{stderr[:1024]}')
+
+        # Check is True when UPX -t validates file - we could try to unpack
         else:
-            self.log.info(f'UPX extractor said this file was not UPX packed:\n{stderr[:1024]}\n{stderr[:1024]}')
+            self.log.info(f'UPX extractor said this file was not UPX packed:\n{check_stderr[:1024]}\n{check_stderr[:1024]}')
         # UPX unpacking is failure prone due to the number of samples that are identified as UPX
         # but are really some minor variant. For that reason we can't really fail the result
         # every time upx has problems with a file.

--- a/unpacker.py
+++ b/unpacker.py
@@ -36,7 +36,7 @@ class Unpacker(ServiceBase):
                                stdout=PIPE, stderr=PIPE).communicate()
         return (stdout, stderr)
 
-    def _fix_p_info(self, packedfile)
+    def _fix_p_info(self, packedfile):
         stream = open(packedfile, 'r+b')
         buff = stream.read()
         upx_index = buff.find(b'UPX!')


### PR DESCRIPTION
Hello
as discussed on discord, here is an upgrade proposal for the UPX unpack service.

### Sumary
Attacker could overwritten p_filesize and p_blocksize with nullbytes two avoid unpacking with UPX
This upgrade fix that by resetting good value.

### Details
1.  Add `_check_upx` function :
this function just call upx -t and return stdout and stderr
2. On `_unpack_upx` orignal func :
add a loop to check (with _check_upx) if file is recognize by upx.
if upx return error like : `CantUnpackException: p_info corrupted`, call function _fix_p_info
3. Add `_fix_p_info` function:
this function check if  p_blocksize or p_filsesize were set to 0. If yes try to fix it
4. Re check with loop
5. Try Unpack 

Also add an else on unpack section to log extraction Error

### Tests
I haven't tested it in ASL yet. I will do it soon.

Locally (copying and pasting the check and fix code into a script), it looks like this:
![image](https://github.com/user-attachments/assets/aad19aa8-8956-4642-9438-ca249668aaaf)

### Warning
I chose to modify the submitted file directly. Please let me know if you prefer to use a third-party file.

regards

Jérémy
